### PR TITLE
Add Network-only deploy driver

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,7 @@ ironic.hardware.interfaces.deploy =
     fake = ironic.drivers.modules.fake:FakeDeploy
     iscsi = ironic.drivers.modules.iscsi_deploy:ISCSIDeploy
     ramdisk = ironic.drivers.modules.pxe:PXERamdiskDeploy
+    network-only = ironic.drivers.redfish:NetworkOnlyDeploy
 
 ironic.hardware.interfaces.inspect =
     fake = ironic.drivers.modules.fake:FakeInspect
@@ -182,6 +183,7 @@ ironic.hardware.types =
     irmc = ironic.drivers.irmc:IRMCHardware
     manual-management = ironic.drivers.generic:ManualManagementHardware
     redfish = ironic.drivers.redfish:RedfishHardware
+    redfish-network-appliance = ironic.drivers.redfish:RedfishHardware
     snmp = ironic.drivers.snmp:SNMPHardware
     xclarity = ironic.drivers.xclarity:XClarityHardware
 


### PR DESCRIPTION
Deploy driver that only calls the network driver.
If configured, reboot via redfish after each network change.